### PR TITLE
docs: fix SKILL.md frontmatter and expand README

### DIFF
--- a/.github/skills/code-docs/SKILL.md
+++ b/.github/skills/code-docs/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: "Doxygen Documentation"
+description: "Guidelines for adding Doxygen documentation to C++ headers in the nanoipc repository."
+version: "1.0"
+---
+
 # Skill: Doxygen Documentation
 
 Guidelines for adding Doxygen documentation to C++ headers in this repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # nanoipc
 
-A minimal C++17 IPC library for embedded systems using [nanopb](https://github.com/nanopb/nanopb) (Protocol Buffers) and [nanocobs](https://github.com/charlesnicholson/nanocobs) (COBS framing) over a byte-stream transport such as UART.
+## Purpose
+
+Implementing a reliable IPC (inter-process communication) layer between a host machine and an MCU from scratch in every embedded project is repetitive and error-prone. Existing solutions are either too heavy for constrained devices or are tightly coupled to a specific application-layer protocol (request/response, pub-sub, async, etc.), forcing architectural decisions on the developer.
+
+**nanoipc** solves this by providing a minimal, platform-independent C++17 building block for message exchange over byte-stream transports such as UART. It is deliberately protocol-agnostic: the library handles only serialization and framing, leaving concurrency, sequencing, and application-layer concerns entirely to the application. Any protocol—synchronous request/response, asynchronous fire-and-forget, pub-sub—can be built on top without modification to the library itself.
+
+The library uses [nanopb](https://github.com/nanopb/nanopb) (Protocol Buffers) and [JsonCPP](https://github.com/open-source-parsers/jsoncpp) for message encoding and [nanocobs](https://github.com/charlesnicholson/nanocobs) (COBS framing) for reliable message delimiting on byte streams.
 
 ## Repository layout
 
@@ -53,6 +59,82 @@ nanoipc uses a layered architecture:
    - PbMessageReader/Writer: serialize/deserialize protobuf messages
    - JsonMessageReader/Writer: serialize/deserialize JSON messages using JsonCPP
 
+## Typical usage
+
+### Server side (MCU)
+
+The server runs on a microcontroller. It continuously reads raw bytes from a transport (e.g. UART), accumulates them in a `RingBuffer`, and passes them to a `CobsFrameReader` to decode complete COBS frames. Each frame is then deserialized into an API message by a `JsonMessageReader` or `PbMessageReader`. After processing the request, the server encodes the response, wraps it in a COBS frame with `CobsFrameWriter`, and sends it back over the transport.
+
+```
+UART bytes → RingBuffer → CobsFrameReader → JsonMessageReader → [app logic]
+                                                                       ↓
+UART bytes ← CobsFrameWriter ← JsonMessageWriter ← [app logic response]
+```
+
+### Client side (host / another MCU)
+
+The client serializes a request via a `Writer`, wraps it in a COBS frame, and sends it over the transport. It then reads raw response bytes, decodes the COBS frame, and deserializes the message with a `Reader`.
+
+```
+[app logic] → JsonMessageWriter → CobsFrameWriter → UART
+[app logic] ← JsonMessageReader ← CobsFrameReader ← UART bytes
+```
+
+The `Reader`/`Writer` separation is intentional. nanoipc does **not** implement any application-layer protocol (no request-ID matching, no timeouts, no pub-sub brokering). This keeps the library MCU-friendly and lets you build any protocol on top: synchronous blocking request/response, fully asynchronous pipelines, pub-sub, and so on.
+
+## Integration
+
+### With CMake FetchContent
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    nanoipc
+    GIT_REPOSITORY https://github.com/fedddot/nanoipc.git
+    GIT_TAG        main   # pin to a specific tag or commit for reproducible builds
+)
+
+# Optional: disable what you don't need before making it available
+set(NANOIPC_TESTS OFF)
+set(NANOIPC_LINUX_FEATURES OFF)   # set ON only on Linux host builds
+
+FetchContent_MakeAvailable(nanoipc)
+```
+
+Then link the targets you need:
+
+```cmake
+target_link_libraries(my_target
+    PRIVATE
+    cobs_frame_reader   # COBS framing – reader side
+    cobs_frame_writer   # COBS framing – writer side
+    json_message_reader # JSON message deserialization
+    json_message_writer # JSON message serialization
+    # pb_message_reader / pb_message_writer for Protocol Buffers instead
+)
+```
+
+### With add_subdirectory
+
+Clone or copy the repository into your project tree, then:
+
+```cmake
+set(NANOIPC_TESTS OFF)
+set(NANOIPC_LINUX_FEATURES OFF)
+
+add_subdirectory(nanoipc)
+
+target_link_libraries(my_target PRIVATE cobs_frame_reader json_message_writer)
+```
+
+### CMake options
+
+| Option | Default | Description |
+|---|---|---|
+| `NANOIPC_TESTS` | `ON` | Build the GoogleTest-based test suite. Disable for cross-compiled / resource-constrained builds. |
+| `NANOIPC_LINUX_FEATURES` | `ON` | Build Linux-specific implementations (`LinuxUartCobsFrameReader/Writer`). Disable when targeting bare-metal MCUs. |
+
 ## Running the tests (host)
 
 ```bash
@@ -60,4 +142,3 @@ cmake -B build-tests
 cmake --build build-tests
 ctest --test-dir build-tests
 ```
-


### PR DESCRIPTION
- Add YAML frontmatter to .github/skills/code-docs/SKILL.md to fix the 'missing or malformed YAML frontmatter' skill load error
- Add Purpose section to README explaining the problem nanoipc solves
- Add Typical usage section describing server-side (MCU) and client-side (host) data flow with Reader/Writer separation rationale
- Add Integration section with FetchContent and add_subdirectory examples and a table of all CMake options (NANOIPC_TESTS, NANOIPC_LINUX_FEATURES)

Closes #7