### PR TITLE
feat: update linux_uart_json_client CLI args and add timeout mechanism

### DIFF
--- a/apps/linux_uart_json_client/README.md
+++ b/apps/linux_uart_json_client/README.md
@@ -2,7 +2,7 @@
 
 A command-line application that communicates with an embedded service over UART by sending and receiving JSON messages encoded with COBS framing.
 
-It opens the specified serial port, sends a JSON request (from a file or a built-in default), and prints the JSON response received from the device.
+It opens the specified serial port, sends a JSON request (read from a file), and writes the JSON response to the specified output file.
 
 ## Building
 
@@ -29,16 +29,20 @@ linux_uart_json_client [OPTIONS]
 | `--parity` | `NONE` | Parity: `NONE`, `EVEN`, `ODD`, `MARK`, `SPACE` |
 | `--data-bits` | `8` | Data bits: `5`, `6`, `7`, `8`, `16` |
 | `--stop-bits` | `1` | Stop bits: `1`, `1.5`, `2` |
-| `--request-file` | *(none)* | Path to a JSON file to send. Omit to send a built-in test request. |
+| `--request` | *(required)* | Path to a JSON file containing the request message |
+| `--response` | *(required)* | Path to write the received JSON response |
+| `--timeout` | `3` | Timeout in seconds to wait for a response |
 
 ### Example
 
 ```bash
-# Send a request from a file at 115200 baud
+# Send a request from a file at 115200 baud and save the response
 ./linux_uart_json_client \
     --port /dev/ttyUSB0 \
     --baud 115200 \
-    --request-file request.json
+    --request request.json \
+    --response response.json \
+    --timeout 5
 ```
 
 **Expected output:**
@@ -53,11 +57,6 @@ Received response: {
 }
 ```
 
-If `--request-file` is omitted the application sends a default test message:
+The response JSON is also written to the file specified by `--response`.
 
-```json
-{
-   "payload" : "Hello, world!",
-   "type" : "test_request"
-}
-```
+If the response is not received within the `--timeout` duration, the application prints an error and exits with a non-zero status code.

--- a/apps/linux_uart_json_client/src/linux_uart_json_client.cpp
+++ b/apps/linux_uart_json_client/src/linux_uart_json_client.cpp
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <chrono>
 #include <iostream>
 #include <fstream>
 
@@ -67,7 +68,9 @@ int main(int argc, char* argv[]) {
     std::string parity_str = "NONE";
     unsigned int data_bits = 8;
     std::string stop_bits_str = "1";
-    std::string request_file;
+    std::string request_path;
+    std::string response_path;
+    unsigned int timeout_sec = 3;
     
     app.add_option("--port", port, "Device path (e.g., /dev/ttyACM0, /dev/ttyUSB0)")
         ->default_val("/dev/ttyACM0");
@@ -88,7 +91,15 @@ int main(int argc, char* argv[]) {
         ->default_val("1")
         ->check(CLI::IsMember({"1", "1.5", "2"}));
     
-    app.add_option("--request-file", request_file, "Path to JSON file containing request message");
+    app.add_option("--request", request_path, "Path to JSON file containing request message")
+        ->required();
+    
+    app.add_option("--response", response_path, "Path to write the JSON response")
+        ->required();
+    
+    app.add_option("--timeout", timeout_sec, "Timeout in seconds waiting for response")
+        ->default_val("3")
+        ->check(CLI::NonNegativeNumber);
     
     CLI11_PARSE(app, argc, argv);
     
@@ -99,11 +110,11 @@ int main(int argc, char* argv[]) {
     
     // Read request message
     Json::Value request;
-    if (!request_file.empty()) {
-        request = read_json_from_file(request_file);
-    } else {
-        request["type"] = "test_request";
-        request["payload"] = "Hello, world!";
+    try {
+        request = read_json_from_file(request_path);
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return 1;
     }
     std::cout << "Sending request: " << request.toStyledString() << std::endl;
     
@@ -131,14 +142,30 @@ int main(int argc, char* argv[]) {
     uart.flushReceiver();
     json_writer.write(request);
     
-    // Read response
+    // Read response with timeout
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
     while (true) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            std::cerr << "Timeout: no response received within " << timeout_sec << " second(s)" << std::endl;
+            uart.closeDevice();
+            return 1;
+        }
         const auto response = json_reader.read();
         if (!response.has_value()) {
             continue;
         }
         const auto msg = response.value();
         std::cout << "Received response: " << msg.toStyledString() << std::endl;
+        
+        // Write response to file
+        std::ofstream response_file(response_path);
+        if (!response_file.is_open()) {
+            std::cerr << "Failed to open response file for writing: " << response_path << std::endl;
+            uart.closeDevice();
+            return 1;
+        }
+        Json::StreamWriterBuilder writer_builder;
+        response_file << Json::writeString(writer_builder, msg);
         break;
     }
     


### PR DESCRIPTION
## Summary

Closes #10

## Changes

### CLI arguments
- Renamed `--request-file` → `--request` (now mandatory; exits with failure if not provided)
- Added `--response` mandatory argument — path to write the received JSON response
- Added `--timeout` optional argument (default: 3 s) — max seconds to wait for a response

### Timeout mechanism
Replaced the infinite `while(true)` response loop with a `std::chrono::steady_clock` deadline. If no response arrives within the timeout, the app prints an error message and exits with a non-zero status code.

### Response file output
On success the response JSON is written to the file specified by `--response`.

### Docs
Updated `apps/linux_uart_json_client/README.md` to reflect all new arguments and behaviour.