### PR TITLE
Add linux_uart_cobs_client application

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,4 @@
 if(NANOIPC_LINUX_FEATURES)
     add_subdirectory(linux_uart_json_client)
+    add_subdirectory(linux_uart_cobs_client)
 endif()

--- a/apps/linux_uart_cobs_client/CMakeLists.txt
+++ b/apps/linux_uart_cobs_client/CMakeLists.txt
@@ -1,0 +1,16 @@
+FetchContent_Declare(
+    cli11
+    GIT_REPOSITORY https://github.com/CLIUtils/CLI11.git
+    GIT_TAG        v2.4.1
+)
+FetchContent_MakeAvailable(cli11)
+
+add_executable(linux_uart_cobs_client ${CMAKE_CURRENT_LIST_DIR}/src/linux_uart_cobs_client.cpp)
+target_link_libraries(
+    linux_uart_cobs_client
+    PRIVATE
+    CLI11::CLI11
+    linux_uart_cobs_frame_reader
+    linux_uart_cobs_frame_writer
+    serialib_interface
+)

--- a/apps/linux_uart_cobs_client/README.md
+++ b/apps/linux_uart_cobs_client/README.md
@@ -1,0 +1,61 @@
+# linux_uart_cobs_client
+
+A command-line application that acts as a COBS/UART framing bridge for host-side clients written in languages other than C++. It reads a raw binary payload from a file, wraps it in a COBS frame, sends it over a UART serial port, receives a COBS-framed response, strips the framing, and writes the raw binary payload to an output file.
+
+This makes it useful as a thin transport helper for any language that has its own serialisation stack (e.g. Rust with `prost` for Protobuf). The application performs no JSON serialisation or deserialisation.
+
+## Building
+
+The app is part of the top-level nanoipc CMake project and is only compiled when the `NANOIPC_LINUX_FEATURES` option is enabled (it is **on** by default).
+
+```bash
+# From the repository root
+cmake -S . -B build -DNANOIPC_LINUX_FEATURES=ON -DNANOIPC_TESTS=OFF
+cmake --build build --target linux_uart_cobs_client
+```
+
+The resulting binary is placed in `build/apps/linux_uart_cobs_client/`.
+
+## Running
+
+```
+linux_uart_cobs_client [OPTIONS]
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `--port` | `/dev/ttyACM0` | Serial device path (e.g. `/dev/ttyUSB0`) |
+| `--baud` | `9600` | Baud rate (e.g. `115200`, `230400`) |
+| `--parity` | `NONE` | Parity: `NONE`, `EVEN`, `ODD`, `MARK`, `SPACE` |
+| `--data-bits` | `8` | Data bits: `5`, `6`, `7`, `8`, `16` |
+| `--stop-bits` | `1` | Stop bits: `1`, `1.5`, `2` |
+| `--request` | *(required)* | Path to binary file containing the raw request payload |
+| `--response` | *(required)* | Path to write the raw binary response payload |
+| `--timeout` | `3` | Timeout in seconds to wait for a response |
+
+### Example – Rust client sending Protobuf over UART
+
+```bash
+# 1. Rust serialises a Protobuf request and writes it to a file
+#    (done inside the Rust binary)
+
+# 2. Shell out to linux_uart_cobs_client to handle COBS/UART framing
+./linux_uart_cobs_client \
+    --port /dev/ttyUSB0 \
+    --baud 115200 \
+    --request request.bin \
+    --response response.bin \
+    --timeout 5
+
+# 3. Rust reads response.bin and deserialises the Protobuf response
+#    (done inside the Rust binary)
+```
+
+**Expected output:**
+
+```
+Sending 32 byte(s) from request.bin
+Received 48 byte(s), writing to response.bin
+```
+
+If the response is not received within the `--timeout` duration, the application prints an error and exits with a non-zero status code.

--- a/apps/linux_uart_cobs_client/src/linux_uart_cobs_client.cpp
+++ b/apps/linux_uart_cobs_client/src/linux_uart_cobs_client.cpp
@@ -1,0 +1,151 @@
+#include <chrono>
+#include <cstdint>
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include <CLI/CLI.hpp>
+
+#include "linux_uart_cobs_frame_reader.hpp"
+#include "linux_uart_cobs_frame_writer.hpp"
+#include "serialib.h"
+
+using namespace nanoipc;
+
+enum: std::size_t { BUFF_SIZE = 4096UL };
+
+SerialParity parse_parity(const std::string& parity_str) {
+    if (parity_str == "NONE") return SerialParity::SERIAL_PARITY_NONE;
+    if (parity_str == "EVEN") return SerialParity::SERIAL_PARITY_EVEN;
+    if (parity_str == "ODD") return SerialParity::SERIAL_PARITY_ODD;
+    if (parity_str == "MARK") return SerialParity::SERIAL_PARITY_MARK;
+    if (parity_str == "SPACE") return SerialParity::SERIAL_PARITY_SPACE;
+    throw std::runtime_error("Invalid parity: " + parity_str);
+}
+
+SerialDataBits parse_data_bits(unsigned int bits) {
+    switch (bits) {
+        case 5: return SerialDataBits::SERIAL_DATABITS_5;
+        case 6: return SerialDataBits::SERIAL_DATABITS_6;
+        case 7: return SerialDataBits::SERIAL_DATABITS_7;
+        case 8: return SerialDataBits::SERIAL_DATABITS_8;
+        case 16: return SerialDataBits::SERIAL_DATABITS_16;
+        default: throw std::runtime_error("Invalid data bits: " + std::to_string(bits));
+    }
+}
+
+SerialStopBits parse_stop_bits(const std::string& stop_bits_str) {
+    if (stop_bits_str == "1") return SerialStopBits::SERIAL_STOPBITS_1;
+    if (stop_bits_str == "1.5") return SerialStopBits::SERIAL_STOPBITS_1_5;
+    if (stop_bits_str == "2") return SerialStopBits::SERIAL_STOPBITS_2;
+    throw std::runtime_error("Invalid stop bits: " + stop_bits_str);
+}
+
+std::vector<std::uint8_t> read_binary_file(const std::string& filepath) {
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Cannot open request file: " + filepath);
+    }
+    return std::vector<std::uint8_t>(
+        std::istreambuf_iterator<char>(file),
+        std::istreambuf_iterator<char>()
+    );
+}
+
+int main(int argc, char* argv[]) {
+    CLI::App app("UART COBS Client - Send and receive raw binary payloads over UART using COBS framing");
+
+    std::string port = "/dev/ttyACM0";
+    unsigned int baud = 9600;
+    std::string parity_str = "NONE";
+    unsigned int data_bits = 8;
+    std::string stop_bits_str = "1";
+    std::string request_path;
+    std::string response_path;
+    unsigned int timeout_sec = 3;
+
+    app.add_option("--port", port, "Device path (e.g., /dev/ttyACM0, /dev/ttyUSB0)")
+        ->default_val("/dev/ttyACM0");
+
+    app.add_option("--baud", baud, "Baud rate (e.g., 9600, 115200, 230400)")
+        ->default_val("9600")
+        ->check(CLI::PositiveNumber);
+
+    app.add_option("--parity", parity_str, "Parity type: NONE, EVEN, ODD, MARK, SPACE")
+        ->default_val("NONE")
+        ->check(CLI::IsMember({"NONE", "EVEN", "ODD", "MARK", "SPACE"}));
+
+    app.add_option("--data-bits", data_bits, "Number of data bits: 5, 6, 7, 8, 16")
+        ->default_val("8")
+        ->check(CLI::IsMember({5, 6, 7, 8, 16}));
+
+    app.add_option("--stop-bits", stop_bits_str, "Number of stop bits: 1, 1.5, 2")
+        ->default_val("1")
+        ->check(CLI::IsMember({"1", "1.5", "2"}));
+
+    app.add_option("--request", request_path, "Path to binary file containing the raw request payload")
+        ->required();
+
+    app.add_option("--response", response_path, "Path to write the raw binary response payload")
+        ->required();
+
+    app.add_option("--timeout", timeout_sec, "Timeout in seconds waiting for a response")
+        ->default_val("3")
+        ->check(CLI::NonNegativeNumber);
+
+    CLI11_PARSE(app, argc, argv);
+
+    SerialParity parity = parse_parity(parity_str);
+    SerialDataBits db = parse_data_bits(data_bits);
+    SerialStopBits sb = parse_stop_bits(stop_bits_str);
+
+    std::vector<std::uint8_t> request_payload;
+    try {
+        request_payload = read_binary_file(request_path);
+    } catch (const std::exception& ex) {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+    std::cout << "Sending " << request_payload.size() << " byte(s) from " << request_path << std::endl;
+
+    serialib uart;
+    const auto open_result = uart.openDevice(port.c_str(), baud, db, parity, sb);
+    if (open_result != 1) {
+        std::cerr << "Failed to open serial port: " << port << std::endl;
+        return 1;
+    }
+
+    LinuxUartCobsFrameReader<BUFF_SIZE> cobs_reader(&uart);
+    LinuxUartCobsFrameWriter cobs_writer(&uart);
+
+    uart.flushReceiver();
+    cobs_writer.write(request_payload);
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+    while (true) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            std::cerr << "Timeout: no response received within " << timeout_sec << " second(s)" << std::endl;
+            uart.closeDevice();
+            return 1;
+        }
+        const auto response = cobs_reader.read();
+        if (!response.has_value()) {
+            continue;
+        }
+        const auto& payload = response.value();
+        std::cout << "Received " << payload.size() << " byte(s), writing to " << response_path << std::endl;
+
+        std::ofstream response_file(response_path, std::ios::binary);
+        if (!response_file.is_open()) {
+            std::cerr << "Failed to open response file for writing: " << response_path << std::endl;
+            uart.closeDevice();
+            return 1;
+        }
+        response_file.write(reinterpret_cast<const char*>(payload.data()), static_cast<std::streamsize>(payload.size()));
+        break;
+    }
+
+    uart.closeDevice();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds a new `linux_uart_cobs_client` CLI application under `apps/linux_uart_cobs_client`, mirroring the structure of `linux_uart_json_client`.

The application acts as a thin COBS/UART framing bridge:
1. Reads raw binary payload from `--request` file
2. Wraps it in a COBS frame and sends it over UART
3. Waits up to `--timeout` seconds for a COBS-framed response
4. Strips COBS framing and writes raw bytes to `--response` file

This is useful for host-side clients written in other languages (e.g. Rust + prost for Protobuf) that manage their own serialisation and only need a transport helper for COBS framing over UART.

## Changes
- `apps/linux_uart_cobs_client/CMakeLists.txt` – builds the executable, links `linux_uart_cobs_frame_reader`, `linux_uart_cobs_frame_writer`, `serialib_interface`, and `CLI11`
- `apps/linux_uart_cobs_client/src/linux_uart_cobs_client.cpp` – implementation
- `apps/linux_uart_cobs_client/README.md` – documentation with purpose, build, and usage example
- `apps/CMakeLists.txt` – registers the new subdirectory

Closes #14